### PR TITLE
fix: fetch all releases

### DIFF
--- a/fetch-releases.js
+++ b/fetch-releases.js
@@ -1,0 +1,15 @@
+const fetch = require('node-fetch')
+
+const release_url = 'https://api.github.com/repos/electron/electron/releases'
+
+function fetchPage (n = 0, allReleases = []) {
+  return fetch(`${release_url}?per_page=100&page=${n}`)
+    .then(r => r.json())
+    .then(releases => {
+      if (releases.length === 0) return allReleases
+      allReleases.push(...releases)
+      return fetchPage(n + 1, allReleases)
+    })
+}
+
+fetchPage().then(releases => console.log(JSON.stringify(releases, null, 2)))

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "license": "MIT",
   "devDependencies": {
     "lodash": "^4.17.4",
+    "node-fetch": "^2.2.0",
     "npm-run-all": "^4.0.1",
     "require-dir": "^0.3.1"
   },
@@ -17,7 +18,7 @@
     "fetch:electron": "curl https://api.npmjs.org/downloads/range/2016-07-26:2020-01-01/electron > data/electron.json",
     "fetch:electron-prebuilt": "curl https://api.npmjs.org/downloads/range/2010-01-01:2020-01-01/electron-prebuilt > data/electron-prebuilt.json",
     "fetch:electron-prebuilt-compile": "curl https://api.npmjs.org/downloads/range/2010-01-01:2020-01-01/electron-prebuilt-compile > data/electron-prebuilt-compile.json",
-    "fetch:releases": "curl https://api.github.com/repos/electron/electron/releases > releases.json",
+    "fetch:releases": "node fetch-releases.js > releases.json",
     "build": "npm run fetch && node index.js > readme.md && node releases.js >> readme.md",
     "release": "script/release.sh"
   }

--- a/releases.js
+++ b/releases.js
@@ -1,4 +1,4 @@
-const releases = require('./releases.json')
+const releases = require('./releases.json').slice(0, 30)
 
 console.log('\n\n## Asset Downloads\n')
 console.log('> Raw download counts for every released GitHub asset.\n')


### PR DESCRIPTION
I was doing some work graphing GitHub asset downloads to try show Electron version adoption rates, but I hit some snags where the script in this repository that fetches releases, will only fetch the last 30 releases.

This PR updates that to fetch all 437 releases but only puts 30 in the README to be consistent

Example graph with weird drop offs as we lose versions:

![image](https://user-images.githubusercontent.com/6634592/45297224-01f66d80-b548-11e8-9df4-fa7915f5b25b.png)

Unfortunately this means all data before this PR gets merged can't be used for this kind of historical comparison 😢 