### PR TITLE
chore: move scheduled job to actions

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,0 +1,10 @@
+workflow "Update Download Stats" {
+  resolves = ["Check latest statistics"]
+  on = "schedule(30 20 * * *)"
+}
+
+action "Check latest statistics" {
+  uses = "./"
+  runs = "npm run release"
+  secrets = ["GITHUB_TOKEN"]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:alpine
+
+# Labels for GitHub to read the action
+LABEL "com.github.actions.name"="Update Download Stats"
+LABEL "com.github.actions.description"="Checks for and reports download stats for Electron."
+LABEL "com.github.actions.icon"="package"
+LABEL "com.github.actions.color"="gray-dark"
+
+# Copy the package.json and package-lock.json
+COPY package*.json ./
+
+# Install dependencies
+RUN npm ci
+
+# Copy the rest of the repo's code
+COPY . .


### PR DESCRIPTION
Move the `download-stats` update job from heroku to GitHub Actions so that we can delete the heroku app.

![Screen Shot 2019-05-07 at 1 02 55 PM](https://user-images.githubusercontent.com/2036040/57330330-8cd53b00-70ca-11e9-993a-85c3a4432479.png)

cc @MarshallOfSound 