### PR TITLE
chore: use LFS with GitHub workflow

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -9,7 +9,9 @@ jobs:
     name: Check latest statistics
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c  # tag: v3
+      with:
+          lfs: true
     - name: Check latest statistics
       uses: ./
       env:


### PR DESCRIPTION
Also pins the SHA for the checkout action.

Aims to fix rejected pushes (see [latest scheduled run](https://github.com/electron/download-stats/actions/runs/3863796105/jobs/6586201101)) which imply that the the workflow isn't using LFS.