### PR TITLE
chore: don't store releases.json in repo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
 data/*.json filter=lfs diff=lfs merge=lfs -text
-releases.json filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+releases.json

--- a/releases.json
+++ b/releases.json
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:60a385eeee636232d7af0c7e03fdbadca757255c556726d3ec81f314c2359d03
-size 111625046


### PR DESCRIPTION
Doesn't need to be stored in this repo, and it's problematically large (over the 100 MB limit).