### PR TITLE
build(deps): restore semver dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,14 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@octokit/rest": "^20.0.2"
+        "@octokit/rest": "^20.0.2",
+        "lodash": "^4.17.21",
+        "require-dir": "^0.3.1",
+        "semver": "^7.6.3"
       },
       "devDependencies": {
-        "lodash": "^4.17.21",
         "npm-run-all2": "^7.0.1",
-        "prettier": "^3.1.0",
-        "require-dir": "^0.3.1"
+        "prettier": "^3.1.0"
       }
     },
     "node_modules/@octokit/auth-token": {
@@ -206,8 +207,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/memorystream": {
       "version": "0.3.1",
@@ -438,9 +438,20 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/require-dir/-/require-dir-0.3.2.tgz",
       "integrity": "sha1-wdXHXp+//eny5rM+OD209ZS1pqk=",
-      "dev": true,
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/shell-quote": {

--- a/package.json
+++ b/package.json
@@ -8,10 +8,8 @@
   "author": "zeke <zeke@sikelianos.com>",
   "license": "MIT",
   "devDependencies": {
-    "lodash": "^4.17.21",
     "npm-run-all2": "^7.0.1",
-    "prettier": "^3.1.0",
-    "require-dir": "^0.3.1"
+    "prettier": "^3.1.0"
   },
   "scripts": {
     "lint": "prettier --check \"*.js\"",
@@ -25,6 +23,9 @@
     "build": "npm run fetch && node index.js > readme.md && node releases.js >> readme.md"
   },
   "dependencies": {
-    "@octokit/rest": "^20.0.2"
+    "@octokit/rest": "^20.0.2",
+    "lodash": "^4.17.21",
+    "require-dir": "^0.3.1",
+    "semver": "^7.6.3"
   }
 }


### PR DESCRIPTION
Follow-up to #52. `semver` wasn't declared as a dependency in `package.json` but it was being pulled in transitively by `npm-run-all` so when I changed to `npm-run-all2` it ended up being trimmed and caused a failure in the scheduled workflow here.

Restore it and declare it as a dependency properly in `package.json`, as well as reorganizing some of the dependencies. Since this repo is just a script run by scheduled GHA workflow the distinction between dependency and dev dependency is a bit murky, but still worth trying to keep the distinction.