### PR TITLE
fix: remove log statement

### DIFF
--- a/fetch-data.js
+++ b/fetch-data.js
@@ -45,7 +45,6 @@ async function fetchStatistics(pkgs = packages) {
       const rawData = await fetch(url);
       const data = await rawData.json();
       fs.writeFileSync(outputPath, JSON.stringify(data, null, 2), 'utf8');
-      console.log(`${package} download statistics written to ${outputPath}`);
     } catch (e) {
       console.error('Error fetching data:', error);
       process.exit(1);


### PR DESCRIPTION
This is ending up at the top of `README.md` since all output is piped to it.